### PR TITLE
Fix docker mysql Chinese garbled characters

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     image: mysql:8.0
     container_name: supersonic_mysql
     environment:
+      LANG: 'C.UTF-8'  # 设置环境变量
       MYSQL_ROOT_PASSWORD: root_password
       MYSQL_DATABASE: supersonic_db
       MYSQL_USER: supersonic_user


### PR DESCRIPTION
Fix Chinese garbled characters in MySQL databases in Windows and Centos systems

1、已在window10 和centos 7 使用docker测试完成，如果未加环境变量 mysql打开含有中文的表会出现乱码和插入中文问题
Docker testing has been completed on Windows 10 and Centos7. If the environment variable MySQL is not added, opening a table containing Chinese will result in garbled characters
2、使用步骤：
替换原先docker-compose.yml文件
Window10 docker-compose-windows-x86_64.exe up -d
Centos7 docker-compose up -d
